### PR TITLE
Add @pytest.mark support for tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = -v -s --strict --show-capture all
+
+; Ignore classes since we don't use them right now and it prevents collection issues.
+python_classes =
+
+filterwarnings = ignore::DeprecationWarning

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,9 @@
+"""Configuration file for pytest."""
+
+
+def pytest_configure(config) -> None:
+    """A configuration hook for pytest at this scope."""
+    config.addinivalue_line(
+        "markers",
+        "unit: Run only unit tests.",
+    )

--- a/test/test_slmigrate.py
+++ b/test/test_slmigrate.py
@@ -15,6 +15,7 @@ from test import test_constants
 from .context import systemlinkmigrate
 
 
+@pytest.mark.unit
 def test_parse_arguments():
     """TODO: Complete documentation.
 
@@ -38,6 +39,7 @@ def test_parse_arguments():
     )
 
 
+@pytest.mark.unit
 def test_double_action_args():
     """TODO: Complete documentation.
 
@@ -49,6 +51,7 @@ def test_double_action_args():
     assert pytest_wrapped_e.type == SystemExit
 
 
+@pytest.mark.unit
 def test_no_action_args():
     """TODO: Complete documentation.
 
@@ -60,6 +63,7 @@ def test_no_action_args():
     assert pytest_wrapped_e.type == SystemExit
 
 
+@pytest.mark.unit
 def test_determine_migrate_action_capture():
     """TODO: Complete documentation.
 
@@ -72,6 +76,7 @@ def test_determine_migrate_action_capture():
     assert services_to_migrate == test_service_tuple
 
 
+@pytest.mark.unit
 def test_determine_migrate_action_restore():
     """TODO: Complete documentation.
 
@@ -84,6 +89,7 @@ def test_determine_migrate_action_restore():
     assert services_to_migrate == test_service_tuple
 
 
+@pytest.mark.unit
 def test_determine_migrate_action_thdbbg():
     """TODO: Complete documentation.
 
@@ -122,6 +128,7 @@ def test_determine_migrate_action_thdbbg():
 #         assert str(file).endswith(".bzon.gz, .json.gz")
 
 
+@pytest.mark.unit
 def test_capture_migrate_dir():
     """TODO: Complete documentation.
 
@@ -142,6 +149,7 @@ def test_capture_migrate_dir():
     shutil.rmtree(constants.migration_dir)
 
 
+@pytest.mark.unit
 def test_capture_migrate_singlefile():
     """TODO: Complete documentation.
 
@@ -163,6 +171,7 @@ def test_capture_migrate_singlefile():
     shutil.rmtree(constants.migration_dir)
 
 
+@pytest.mark.unit
 def test_missing_migration_directory():
     """TODO: Complete documentation.
 
@@ -182,6 +191,7 @@ def test_missing_migration_directory():
     assert pytest_wrapped_e.value.code != 0
 
 
+@pytest.mark.unit
 def test_missing_service_migration_file():
     """TODO: Complete documentation.
 
@@ -203,6 +213,7 @@ def test_missing_service_migration_file():
     shutil.rmtree(constants.migration_dir)
 
 
+@pytest.mark.unit
 def test_missing_service_migration_dir():
     """TODO: Complete documentation.
 


### PR DESCRIPTION
This change adds support for using @pytest.mark.<your mark string> support to tests.

It adds the following extra files / modules:
* pytest.ini: 
    - for setting pytest defaults and storing custom marks
* conftest.py: 
    - for adding the hook which adds the custom mark strings programmatically to pytest.ini
    - NOTE:  This will become more important as we add non-unit tests in the future