### PR TITLE
Exclude .venv from flake8 linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.flake8]
 max-line-length=120
+exclude=".git,__pycache__,.venv"
 
 [tool.mypy]
 ignore_missing_imports ="True"


### PR DESCRIPTION
[x] This contribution adheres to CONTRIBUTING.md.

What does this Pull Request accomplish?
Exclude .venv from linting

Why should this Pull Request be merged?
I created a virtual environment in .venv before following the instructions in CONTRIBUTING.md. That caused `poetry run task lint` to take a long time and report errors from dependencies

What testing has been done?
`poetry run task lint` completes more quickly, and only analyzes the files in this repo.