### PR TITLE
Disable insecure HTTPS warnings

### DIFF
--- a/manual_test/manual_test_base.py
+++ b/manual_test/manual_test_base.py
@@ -3,9 +3,13 @@ from requests.auth import HTTPBasicAuth
 import requests
 from typing import Type
 from urllib.parse import urljoin
+from urllib3 import disable_warnings, exceptions
 
 
 class ManualTestBase:
+
+    disable_warnings(exceptions.InsecureRequestWarning)
+
     def __init__(self, server: str, username: str, password: str) -> None:
         """
         Constructs the manual test base class.


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.

What does this Pull Request accomplish?
Disables warning about insecure HTTPS from ManualTestBaseClass methods

Why should this Pull Request be merged?
Our test servers tend to be set up with self-signed HTTPS certificates, so the request helpers on ManualTestBaseClass set `verify=False` to disable certificate verification. This caused a warning to be printed for each request, leading to noisy output during test runs.

What testing has been done?
Tested with in-progress file test