### PR TITLE
Make publishing a release not fail if the release already exists on test.pypi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -35,7 +35,7 @@ jobs:
           user: __token__
           password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/
-        continue-on-error: false
+        continue-on-error: true
 
       - name: Publish distribution to PyPI
         if: github.event.action == 'published'


### PR DESCRIPTION
set continue-on-error to true

 This contribution adheres to CONTRIBUTING.md.
[x]

What does this Pull Request accomplish?
set continue-on-error to true so that if a PR merge has already published to the test pypi for a particular version creating a real release wont fail.