### PR TITLE
Make release action run on ubuntu-latest

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-publish:
     if: github.repository == 'ni/NI-SystemLink-Migration'
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
 


### PR DESCRIPTION
 This contribution adheres to CONTRIBUTING.md.
x

What does this Pull Request accomplish?
Run publish on linux because one of the scripts only works on linux.

Why should this Pull Request be merged?
To fix the release pipeline

What testing has been done?
None