### PR TITLE
Separate command line handling from the migration tool entry point

### DIFF
--- a/nislmigrate/migration_tool.py
+++ b/nislmigrate/migration_tool.py
@@ -1,11 +1,31 @@
 from nislmigrate.utility import permission_checker
 from nislmigrate.logs import logging_setup, migration_error
 from nislmigrate.argument_handler import ArgumentHandler
+from nislmigrate.extensibility.migrator_plugin import MigratorPlugin
 from nislmigrate.facades.facade_factory import FacadeFactory
+from nislmigrate.migration_action import MigrationAction
 from nislmigrate.migration_facilitator import MigrationFacilitator
+from typing import List
 
 
-def run_migration_tool():
+def run_migration_tool(
+        services_to_migrate: List[MigratorPlugin],
+        migration_action: MigrationAction,
+        migration_directory: str) -> None:
+    """
+    Runs the migration.
+
+    :param services_to_migrate: The migration plugins to run.
+    :param migration_action: The action to perform.
+    :param migration_directory: The directory where the migrated data is stored.
+    """
+
+    facade_factory = FacadeFactory()
+    migration_facilitator = MigrationFacilitator(facade_factory)
+    migration_facilitator.migrate(services_to_migrate, migration_action, migration_directory)
+
+
+def main():
     """
     The entry point for the NI SystemLink Migration tool.
     """
@@ -20,8 +40,11 @@ def run_migration_tool():
         services_to_migrate = argument_handler.get_list_of_services_to_capture_or_restore()
         migration_directory = argument_handler.get_migration_directory()
 
-        facade_factory = FacadeFactory()
-        migration_facilitator = MigrationFacilitator(facade_factory)
-        migration_facilitator.migrate(services_to_migrate, migration_action, migration_directory)
+        run_migration_tool(services_to_migrate, migration_action, migration_directory)
+
     except Exception as e:
         migration_error.handle_migration_error(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ taskipy = "^1.8.1"
 types-requests = "^2.25.6"
 
 [tool.poetry.scripts]
-nislmigrate = 'nislmigrate.migration_tool:run_migration_tool'
+nislmigrate = 'nislmigrate.migration_tool:main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.

What does this Pull Request accomplish?
Separates the command line handling from the entry point that runs the migration

Why should this Pull Request be merged?
I'm working on integration tests which will call the whole migration process, but not through the command line.

What testing has been done?
`poetry run nislmigrate` still works as before
