### PR TITLE
Make mongo facade configurable

### DIFF
--- a/nislmigrate/facades/mongo_facade.py
+++ b/nislmigrate/facades/mongo_facade.py
@@ -28,13 +28,17 @@ MONGO_BINARIES_DIRECTORY: str = os.path.join(
     "Skyline",
     "NoSqlDatabase",
     "bin")
-MONGO_DUMP_EXECUTABLE_PATH: str = os.path.join(MONGO_BINARIES_DIRECTORY, "mongodump.exe")
-MONGO_RESTORE_EXECUTABLE_PATH: str = os.path.join(MONGO_BINARIES_DIRECTORY, "mongorestore.exe")
+DEFAULT_MONGO_DUMP_EXECUTABLE_PATH: str = os.path.join(MONGO_BINARIES_DIRECTORY, "mongodump.exe")
+DEFAULT_MONGO_RESTORE_EXECUTABLE_PATH: str = os.path.join(MONGO_BINARIES_DIRECTORY, "mongorestore.exe")
 MONGO_EXECUTABLE_PATH: str = os.path.join(MONGO_BINARIES_DIRECTORY, "mongod.exe")
 
 
 class MongoFacade:
     mongo_process_handle: Optional[subprocess.Popen] = None
+
+    mongo_dump_executable_path: str = DEFAULT_MONGO_DUMP_EXECUTABLE_PATH
+    mongo_restore_executable_path: str = DEFAULT_MONGO_RESTORE_EXECUTABLE_PATH
+    start_mongo: bool = True
 
     def capture_database_to_directory(
             self,
@@ -51,7 +55,7 @@ class MongoFacade:
         if not os.path.exists(directory):
             os.makedirs(directory)
         dump_path = os.path.join(directory, dump_name)
-        mongo_dump_command = [MONGO_DUMP_EXECUTABLE_PATH]
+        mongo_dump_command = [self.mongo_dump_executable_path]
         connection_arguments = self.__get_mongo_connection_arguments(configuration)
         mongo_dump_command.extend(connection_arguments)
         mongo_dump_command.append("--archive=" + dump_path)
@@ -73,7 +77,7 @@ class MongoFacade:
         """
         dump_path = os.path.join(directory, dump_name)
         self.validate_can_restore_database_from_directory(directory, dump_name)
-        mongo_restore_command = [MONGO_RESTORE_EXECUTABLE_PATH]
+        mongo_restore_command = [self.mongo_restore_executable_path]
         connection_arguments = self.__get_mongo_connection_arguments(configuration)
         # We need to provide the db option (even though it's redundant with the uri)
         # because of a bug with mongoDB 4.2
@@ -251,7 +255,7 @@ class MongoFacade:
         Begins the mongo DB subprocess on this computer.
         :return: The started subprocess handling mongo DB.
         """
-        if not self.mongo_process_handle:
+        if self.start_mongo and not self.mongo_process_handle:
             arguments = [MONGO_EXECUTABLE_PATH, "--config", MONGO_CONFIGURATION_PATH]
             self.mongo_process_handle = subprocess.Popen(
                 arguments,

--- a/test/facades/test_mongo_facade.py
+++ b/test/facades/test_mongo_facade.py
@@ -6,7 +6,10 @@ from testfixtures import tempdir, TempDirectory
 
 from nislmigrate.facades import mongo_configuration
 from nislmigrate.facades.mongo_configuration import MongoConfiguration
-from nislmigrate.facades.mongo_facade import MongoFacade
+from nislmigrate.facades.mongo_facade import (
+        MongoFacade,
+        DEFAULT_MONGO_DUMP_EXECUTABLE_PATH,
+        DEFAULT_MONGO_RESTORE_EXECUTABLE_PATH)
 
 
 @pytest.mark.unit
@@ -70,6 +73,123 @@ def test_mongo_facade_capture_migration_directory_already_exists_and_empty(
     assert os.path.exists(migration_directory)
     run.assert_called()
     process_open.assert_called()
+
+
+@pytest.mark.unit
+@tempdir()
+@patch('subprocess.run')
+@patch('subprocess.Popen')
+def test_mongo_facade_does_not_start_mongo_when_start_mongo_is_false(
+        start_mongo: Mock,
+        run_capture: Mock,
+        temp_directory: TempDirectory
+        ) -> None:
+
+    migration_directory = make_directory(temp_directory, "migration")
+    assert os.path.exists(migration_directory)
+    configuration = get_fake_mongo_configuration()
+    mongo_facade = MongoFacade()
+    mongo_facade.start_mongo = False
+
+    mongo_facade.capture_database_to_directory(configuration, migration_directory, "testname.gz")
+
+    assert os.path.exists(migration_directory)
+    run_capture.assert_called()
+    start_mongo.assert_not_called()
+
+
+@pytest.mark.unit
+@tempdir()
+@patch('subprocess.run')
+@patch('subprocess.Popen')
+def test_mongo_facade_runs_default_dump_command(
+        start_mongo: Mock,
+        run_capture: Mock,
+        temp_directory: TempDirectory
+        ) -> None:
+
+    migration_directory = make_directory(temp_directory, "migration")
+    assert os.path.exists(migration_directory)
+    configuration = get_fake_mongo_configuration()
+    mongo_facade = MongoFacade()
+
+    mongo_facade.capture_database_to_directory(configuration, migration_directory, "testname.gz")
+
+    run_capture.assert_called_once()
+    assert run_capture.call_args.args[0][0] == DEFAULT_MONGO_DUMP_EXECUTABLE_PATH
+
+
+@pytest.mark.unit
+@tempdir()
+@patch('subprocess.run')
+@patch('subprocess.Popen')
+def test_mongo_facade_runs_configured_dump_command(
+        start_mongo: Mock,
+        run_capture: Mock,
+        temp_directory: TempDirectory
+        ) -> None:
+
+    migration_directory = make_directory(temp_directory, "migration")
+    assert os.path.exists(migration_directory)
+    configuration = get_fake_mongo_configuration()
+    mongo_facade = MongoFacade()
+    mongo_facade.mongo_dump_executable_path = "dump"
+
+    mongo_facade.capture_database_to_directory(configuration, migration_directory, "testname.gz")
+
+    run_capture.assert_called_once()
+    assert run_capture.call_args.args[0][0] == "dump"
+
+
+@pytest.mark.unit
+@tempdir()
+@patch('subprocess.run')
+@patch('subprocess.Popen')
+@patch('os.path.exists')
+def test_mongo_facade_runs_default_restore_command(
+        exists: Mock,
+        start_mongo: Mock,
+        run_capture: Mock,
+        temp_directory: TempDirectory
+        ) -> None:
+
+    attrs = {'method.return_value': True}
+    exists.configure_mock(**attrs)
+    migration_directory = make_directory(temp_directory, "migration")
+    assert os.path.exists(migration_directory)
+    configuration = get_fake_mongo_configuration()
+    mongo_facade = MongoFacade()
+
+    mongo_facade.restore_database_from_directory(configuration, migration_directory, "testname.gz")
+
+    run_capture.assert_called_once()
+    assert run_capture.call_args.args[0][0] == DEFAULT_MONGO_RESTORE_EXECUTABLE_PATH
+
+
+@pytest.mark.unit
+@tempdir()
+@patch('subprocess.run')
+@patch('subprocess.Popen')
+@patch('os.path.exists')
+def test_mongo_facade_runs_configured_restore_command(
+        exists: Mock,
+        start_mongo: Mock,
+        run_capture: Mock,
+        temp_directory: TempDirectory
+        ) -> None:
+
+    attrs = {'method.return_value': True}
+    exists.configure_mock(**attrs)
+    migration_directory = make_directory(temp_directory, "migration")
+    assert os.path.exists(migration_directory)
+    configuration = get_fake_mongo_configuration()
+    mongo_facade = MongoFacade()
+    mongo_facade.mongo_restore_executable_path = "restore"
+
+    mongo_facade.restore_database_from_directory(configuration, migration_directory, "testname.gz")
+
+    run_capture.assert_called_once()
+    assert run_capture.call_args.args[0][0] == "restore"
 
 
 def make_directory(temp_directory: TempDirectory, name: str) -> str:


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.

What does this Pull Request accomplish?
Make the mongo facade configurable:
- starting mongo can be disabled
- executables for dump / restore can be set

Why should this Pull Request be merged?
So an integration test will be able to use the real facade but without a mongo

What testing has been done?
Existing tests pass, new unit tests added and pass.
