### PR TITLE
RFC: Additional parameters to migrators

### DIFF
--- a/nislmigrate/argument_handler.py
+++ b/nislmigrate/argument_handler.py
@@ -66,6 +66,13 @@ class ArgumentHandler:
             raise MigrationError(NO_SERVICES_SPECIFIED_ERROR_TEXT)
         return enabled_plugins
 
+    def get_migrator_arguments(self) -> dict:
+        d = vars(parsed_arguments)
+        migrator_arguments = {}
+        for p in self.__get_enabled_plugins():
+            prefix = f'--{p.argument}-'
+            migrator_arguments[p.argument] = { k, v for k, v in d.items() if k.begins(prefix) }
+
     def __get_enabled_plugins(self) -> List[MigratorPlugin]:
         arguments: List[str] = self.__get_enabled_plugin_arguments()
         return [self.__find_plugin_for_argument(argument) for argument in arguments]

--- a/nislmigrate/extensibility/migrator_plugin.py
+++ b/nislmigrate/extensibility/migrator_plugin.py
@@ -62,7 +62,7 @@ class MigratorPlugin(abc.ABC):
         return self.__cached_config
 
     @abc.abstractmethod
-    def capture(self, migration_directory: str, facade_factory: FacadeFactory) -> None:
+    def capture(self, migration_directory: str, facade_factory: FacadeFactory, arguments: dict) -> None:
         """
         Captures the given service from SystemLink.
         :param migration_directory: the root path to perform the capture to.
@@ -72,7 +72,7 @@ class MigratorPlugin(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def restore(self, migration_directory: str, facade_factory: FacadeFactory) -> None:
+    def restore(self, migration_directory: str, facade_factory: FacadeFactory, arguments: dict) -> None:
         """
         Restores the given service to SystemLink.
         :param migration_directory: the root path to perform the restore from.
@@ -95,12 +95,8 @@ class MigratorPlugin(abc.ABC):
     def add_additional_arguments(self, parser: ArgumentParser) -> None:
         """
         Adds additional command line arguments to control the behavior of the migration.
-        Arguments names must be unique across all migrators.
+        Arguments names must begin with '--<plugin name>-'.
 
         :param parser: The parser used for command line arguments.
         """
         pass
-
-    @property
-    def arguments(self) -> Namespace:
-        return __arguments

--- a/nislmigrate/migration_tool.py
+++ b/nislmigrate/migration_tool.py
@@ -12,7 +12,8 @@ def run_migration_tool(
         facade_factory: FacadeFactory,
         services_to_migrate: List[MigratorPlugin],
         migration_action: MigrationAction,
-        migration_directory: str) -> None:
+        migration_directory: str,
+        migrator_arguments: dict) -> None:
     """
     Runs the migration.
 
@@ -22,7 +23,7 @@ def run_migration_tool(
     """
 
     migration_facilitator = MigrationFacilitator(facade_factory)
-    migration_facilitator.migrate(services_to_migrate, migration_action, migration_directory)
+    migration_facilitator.migrate(services_to_migrate, migration_action, migration_directory, migrator_arguments)
 
 
 def main():
@@ -39,9 +40,10 @@ def main():
         migration_action = argument_handler.get_migration_action()
         services_to_migrate = argument_handler.get_list_of_services_to_capture_or_restore()
         migration_directory = argument_handler.get_migration_directory()
+        migrator_arguments = argument_handler.get_migrator_arguments()
 
         facade_factory = FacadeFactory()
-        run_migration_tool(facade_factory, services_to_migrate, migration_action, migration_directory)
+        run_migration_tool(facade_factory, services_to_migrate, migration_action, migration_directory, migrator_arguments)
 
     except Exception as e:
         migration_error.handle_migration_error(e)

--- a/nislmigrate/migrators/file_migrator.py
+++ b/nislmigrate/migrators/file_migrator.py
@@ -31,7 +31,7 @@ class FileMigrator(MigratorPlugin):
     def help(self):
         return "Migrate ingested files"
 
-    def capture(self, migration_directory: str, facade_factory: FacadeFactory):
+    def capture(self, migration_directory: str, facade_factory: FacadeFactory, migrator_arguments: dict):
         mongo_facade: MongoFacade = facade_factory.get_mongo_facade()
         file_facade: FileSystemFacade = facade_factory.get_file_system_facade()
         mongo_configuration: MongoConfiguration = MongoConfiguration(self.config(facade_factory))
@@ -41,10 +41,12 @@ class FileMigrator(MigratorPlugin):
             mongo_configuration,
             migration_directory,
             self.name)
-        file_facade.copy_directory(
-            self.__data_directory(facade_factory),
-            file_migration_directory,
-            False)
+
+        if migrator_arguments['--files-metadata-only']:
+            file_facade.copy_directory(
+                self.__data_directory(facade_factory),
+                file_migration_directory,
+                False)
 
     def restore(self, migration_directory: str, facade_factory: FacadeFactory):
         mongo_facade: MongoFacade = facade_factory.get_mongo_facade()
@@ -56,10 +58,12 @@ class FileMigrator(MigratorPlugin):
             mongo_configuration,
             migration_directory,
             self.name)
-        file_facade.copy_directory(
-            file_migration_directory,
-            self.__data_directory(facade_factory),
-            True)
+
+        if migrator_arguments['--files-metadata-only']:
+            file_facade.copy_directory(
+                file_migration_directory,
+                self.__data_directory(facade_factory),
+                True)
 
     def pre_restore_check(self, migration_directory: str, facade_factory: FacadeFactory) -> None:
         mongo_facade: MongoFacade = facade_factory.get_mongo_facade()


### PR DESCRIPTION
For file we need an argument to tell it to only migrate the database, not the files themselves. Here is what I'm thinking for how to let migrators add custom parameters. This is not currently functional, probably not even syntactically correct yet - I'd like to get feedback on overall approach first.

- Added a new method that the migrators can implement to specify arguments
- The argument must begin with the migrator name/argument. For example for files migrator (`--files`) any additional arguments must begin with `--files-` - like `--files-metadata-only`.
- Arguments are passed to the capture / restore methods on the migrator plugin. The only arguments that match the pattern are passed.