### PR TITLE
Revert documentation change that no longer applies

### DIFF
--- a/nislmigrate/argument_handler.py
+++ b/nislmigrate/argument_handler.py
@@ -71,7 +71,7 @@ class ArgumentHandler:
         Generate a list of migration strategies to use during migration,
         based on the given arguments.
 
-        :return: A list of selected migration actions with the parameters for each action.
+        :return: A list of selected migration actions.
         """
         enabled_plugins = (self.plugin_loader.get_plugins() if self.__is_all_service_migration_flag_present()
                            else self.__get_enabled_plugins())


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.


What does this Pull Request accomplish?
Revert a documentation change that added during an intermediate change #72, but didn't apply in the final commit. I had intended to include this in that PR, but somehow it didn't get pushed.

Why should this Pull Request be merged?
Ensure documentation is accurate

What testing has been done?
PR Checks
