### PR TITLE
Fix pre_restore_check being called with different arguments before restore.

### DIFF
--- a/nislmigrate/migration_facilitator.py
+++ b/nislmigrate/migration_facilitator.py
@@ -67,7 +67,8 @@ class MigrationFacilitator:
         permission_checker.verify_force_if_restoring(is_force_migration_flag_present, self._action)
 
         if self._action == MigrationAction.RESTORE:
-            plugin: MigratorPlugin
-            for plugin in self._migrators:
-                arguments = self._argument_handler.get_migrator_additional_arguments(plugin)
-                plugin.pre_restore_check(self._migration_directory, self.facade_factory, arguments)
+            migrator: MigratorPlugin
+            for migrator in self._migrators:
+                migrator_directory = os.path.join(self._migration_directory, migrator.name)
+                arguments = self._argument_handler.get_migrator_additional_arguments(migrator)
+                migrator.pre_restore_check(migrator_directory, self.facade_factory, arguments)


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.

What does this Pull Request accomplish?
Fix pre_restore_check being called with different arguments before restore.

Why should this Pull Request be merged?
So that migrator plugins can accurately decide whether they can be restored or not.

What testing has been done?
PR checks.
