### PR TITLE
Add pre capture check that migrators can implement

### DIFF
--- a/nislmigrate/extensibility/migrator_plugin.py
+++ b/nislmigrate/extensibility/migrator_plugin.py
@@ -110,7 +110,22 @@ class MigratorPlugin(abc.ABC):
             facade_factory: FacadeFactory,
             arguments: Dict[str, Any]) -> None:
         """
-        Raises a MigrationError if the service anticipates an error migrating.
+        Raises a MigrationError if the service anticipates an error restoring.
+
+        :param migration_directory: The directory to migrate to.
+        :param facade_factory: Factory that produces objects capable of doing
+                         actual restore operations.
+        :param arguments: Dictionary containing any command line argument values defined in add_additional_arguments.
+        """
+        pass
+
+    def pre_capture_check(
+            self,
+            migration_directory: str,
+            facade_factory: FacadeFactory,
+            arguments: Dict[str, Any]) -> None:
+        """
+        Raises a MigrationError if the service anticipates an error capturing.
 
         :param migration_directory: The directory to migrate to.
         :param facade_factory: Factory that produces objects capable of doing

--- a/nislmigrate/migration_facilitator.py
+++ b/nislmigrate/migration_facilitator.py
@@ -66,9 +66,13 @@ class MigrationFacilitator:
         is_force_migration_flag_present = self._argument_handler.is_force_migration_flag_present()
         permission_checker.verify_force_if_restoring(is_force_migration_flag_present, self._action)
 
-        if self._action == MigrationAction.RESTORE:
-            migrator: MigratorPlugin
-            for migrator in self._migrators:
-                migrator_directory = os.path.join(self._migration_directory, migrator.name)
-                arguments = self._argument_handler.get_migrator_additional_arguments(migrator)
+        migrator: MigratorPlugin
+        for migrator in self._migrators:
+            migrator_directory = os.path.join(self._migration_directory, migrator.name)
+            arguments = self._argument_handler.get_migrator_additional_arguments(migrator)
+            if self._action == MigrationAction.CAPTURE:
+                migrator.pre_capture_check(migrator_directory, self.facade_factory, arguments)
+            elif self._action == MigrationAction.RESTORE:
                 migrator.pre_restore_check(migrator_directory, self.facade_factory, arguments)
+            else:
+                raise ValueError('Migration action is not the correct type.')


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.

What does this Pull Request accomplish?
Add a pre-capture check that can be implemented by migrator plugins

Why should this Pull Request be merged?
If the tool can determine upfront that the capture/restore will fail, then the tool should fail upfront to avoid an incomplete capture.

What testing has been done?
Added unit testing
