### PR TITLE
Ignore Thumbs.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ poetry.lock
 
 # Test output
 .test/
+
+# Windows thumbnail database
+Thumbs.db


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.

What does this Pull Request accomplish?
Ignore Thumbs.db file that windows creates now that there is an image in manual_test/assets

Why should this Pull Request be merged?
To avoid accidentally adding the file to git

What testing has been done?
`git status` no longer reports Thumbs.db as an untracked file