### PR TITLE
Add modify action for updating file paths without migrating.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ To restore the data for all supported services at once, the `--all` flag can be 
 nislmigrate restore --all --secret <password>
 ```
 
+### Modify
+
+To modify entries in the database in-place without doing a restore run the tool with elevated permissions and use the `modify` option. `modify` currently only works to modify the files' service database entries.
+
+#### Updating after moving files
+
+After moving the storage location of the files uploaded to the Files service the database will need to be updated to reflect the new location. The `--files-change-file-store-root` argument can be used for this, either as part of a `restore` operation or in-place as part of a `modify` operation. When used with `restore` the old root location is inferred from the database. When used with `modify` the old root location must be specified with the `--files-file-store-root` argument.
+
+> :warning: `modify` will modify the database directly. A backup of the database should be taken before any modifiations using `nislmigrate capture --files --files-metadata-only`
+
+To modify the files root location after moving the files to a new drive:
+```bash
+cp -r -f C:\old\file\store X:\new\file\store
+nislmigrate modify --files --files-change-file-store-root X:\new\file\store --files-file-store-root C:\old\file\store
+```
+
+To modify the files root location after moving the files to an S3 bucket:
+```bash
+aws s3 sync C:\old\file\store s3://my-systemlink-bucket/my-files
+nislmigrate modify --files --files-change-file-store-root s3://my-systemlink-bucket/my-files --files-file-store-root C:\old\file\store --files-switch-to-forward-slashes
+```
+
 ### Migration
 >:warning: Server B must be a clean SystemLink installation, any existing data will be deleted.
 

--- a/nislmigrate/argument_handler.py
+++ b/nislmigrate/argument_handler.py
@@ -10,10 +10,13 @@ from nislmigrate.logs.migration_error import MigrationError
 from nislmigrate.extensibility.migrator_plugin_loader import MigratorPluginLoader
 from nislmigrate.extensibility.migrator_plugin import MigratorPlugin, ArgumentManager
 
-ACTION_ARGUMENT = 'action'
 PROGRAM_NAME = 'nislmigrate'
+DEFAULT_MIGRATION_DIRECTORY = os.path.expanduser('~\\Documents\\migration')
+
+ACTION_ARGUMENT = 'action'
 CAPTURE_ARGUMENT = 'capture'
 RESTORE_ARGUMENT = 'restore'
+MODIFY_ARGUMENT = 'modify'
 ALL_SERVICES_ARGUMENT = 'all'
 VERBOSITY_ARGUMENT = 'verbosity'
 DEBUG_VERBOSITY_ARGUMENT = 'debug'
@@ -21,7 +24,6 @@ DEBUG_VERBOSITY_ARGUMENT_FLAG = 'd'
 SILENT_VERBOSITY_ARGUMENT = 'silent'
 SILENT_VERBOSITY_ARGUMENT_FLAG = 's'
 MIGRATION_DIRECTORY_ARGUMENT = 'dir'
-DEFAULT_MIGRATION_DIRECTORY = os.path.expanduser('~\\Documents\\migration')
 SECRET_ARGUMENT = 'secret'
 FORCE_ARGUMENT = 'force'
 FORCE_ARGUMENT_FLAG = 'f'
@@ -36,7 +38,7 @@ Must specify at least one service to migrate, or migrate all services with the `
 
 Run `nislmigrate capture/restore --help` to list all supported services."""
 
-CAPTURE_OR_RESTORE_NOT_PROVIDED_ERROR_TEXT = 'The "capture" or "restore" argument must be provided'
+CAPTURE_OR_RESTORE_NOT_PROVIDED_ERROR_TEXT = 'The "capture", "restore" or "modify" argument must be provided'
 SERVICE_NOT_INSTALLED_ERROR_TEXT_FORMAT = """
 
 Service '{service_name}' cannot be migrated because the specified service is not installed locally.
@@ -166,7 +168,7 @@ class ArgumentHandler:
         ]
 
     def get_migration_action(self) -> MigrationAction:
-        """Determines whether to capture or restore based on the arguments.
+        """Determines what migration action to perform based on the arguments.
 
         :return: MigrationAction.RESTORE or MigrationAction.CAPTURE.
         """
@@ -174,6 +176,8 @@ class ArgumentHandler:
             return MigrationAction.RESTORE
         elif self.parsed_arguments.action == CAPTURE_ARGUMENT:
             return MigrationAction.CAPTURE
+        elif self.parsed_arguments.action == MODIFY_ARGUMENT:
+            return MigrationAction.MODIFY
         elif self.parsed_arguments.action == LIST_INSTALLED_SERVICES_ARGUMENT:
             return MigrationAction.LIST
         else:

--- a/nislmigrate/argument_handler.py
+++ b/nislmigrate/argument_handler.py
@@ -36,9 +36,9 @@ NO_SERVICES_SPECIFIED_ERROR_TEXT = """
 
 Must specify at least one service to migrate, or migrate all services with the `--all` flag.
 
-Run `nislmigrate capture/restore --help` to list all supported services."""
+Run `nislmigrate capture/restore/modify --help` to list all supported services."""
 
-CAPTURE_OR_RESTORE_NOT_PROVIDED_ERROR_TEXT = 'The "capture", "restore" or "modify" argument must be provided'
+MIGRATION_OPERATION_NOT_PROVIDED_ERROR_TEXT = 'The "capture", "restore" or "modify" argument must be provided'
 SERVICE_NOT_INSTALLED_ERROR_TEXT_FORMAT = """
 
 Service '{service_name}' cannot be migrated because the specified service is not installed locally.
@@ -48,6 +48,7 @@ that are currently installed."""
 
 CAPTURE_COMMAND_HELP = 'use capture to pull data and settings off of a SystemLink server'
 RESTORE_COMMAND_HELP = 'use restore to push captured data and settings to a clean SystemLink server'
+MODIFY_COMMAND_HELP = 'use modify to update existing data or settings of a SystemLink server in-place'
 DIRECTORY_ARGUMENT_HELP = 'specify the directory used for migrated data (defaults to documents)'
 ALL_SERVICES_ARGUMENT_HELP = 'use all provided migrator plugins during a capture or restore operation'
 FORCE_ARGUMENT_HELP = 'allows capture to delete existing data on the SystemLink server prior to restore'
@@ -170,7 +171,7 @@ class ArgumentHandler:
     def get_migration_action(self) -> MigrationAction:
         """Determines what migration action to perform based on the arguments.
 
-        :return: MigrationAction.RESTORE or MigrationAction.CAPTURE.
+        :return: MigrationAction corresponding to the argument string
         """
         if self.parsed_arguments.action == RESTORE_ARGUMENT:
             return MigrationAction.RESTORE
@@ -181,7 +182,7 @@ class ArgumentHandler:
         elif self.parsed_arguments.action == LIST_INSTALLED_SERVICES_ARGUMENT:
             return MigrationAction.LIST
         else:
-            raise MigrationError(CAPTURE_OR_RESTORE_NOT_PROVIDED_ERROR_TEXT)
+            raise MigrationError(MIGRATION_OPERATION_NOT_PROVIDED_ERROR_TEXT)
 
     def get_migration_directory(self) -> str:
         """Gets the migration directory path based on the parsed arguments.
@@ -228,6 +229,7 @@ class ArgumentHandler:
             f'--{FORCE_ARGUMENT}',
             help=FORCE_ARGUMENT_HELP,
             action='store_true')
+        sub_parser.add_parser(MODIFY_ARGUMENT, help=MODIFY_COMMAND_HELP, parents=[parent_parser])
         sub_parser.add_parser(LIST_INSTALLED_SERVICES_ARGUMENT, help=LIST_INSTALLED_SERVICES_ARGUMENT_HELP)
 
     @staticmethod

--- a/nislmigrate/extensibility/migrator_plugin.py
+++ b/nislmigrate/extensibility/migrator_plugin.py
@@ -127,7 +127,6 @@ class MigratorPlugin(abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
     def modify(self, facade_factory: FacadeFactory, arguments: Dict[str, Any]) -> None:
         """
         Modifies the service without capturing or restoring it.
@@ -153,6 +152,21 @@ class MigratorPlugin(abc.ABC):
         pass
 
     def pre_capture_check(
+            self,
+            migration_directory: str,
+            facade_factory: FacadeFactory,
+            arguments: Dict[str, Any]) -> None:
+        """
+        Raises a MigrationError if the service anticipates an error capturing.
+
+        :param migration_directory: The directory to migrate to.
+        :param facade_factory: Factory that produces objects capable of doing
+                         actual restore operations.
+        :param arguments: Dictionary containing any command line argument values defined in add_additional_arguments.
+        """
+        pass
+
+    def pre_modify_check(
             self,
             migration_directory: str,
             facade_factory: FacadeFactory,

--- a/nislmigrate/extensibility/migrator_plugin.py
+++ b/nislmigrate/extensibility/migrator_plugin.py
@@ -128,6 +128,15 @@ class MigratorPlugin(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def modify(self, facade_factory: FacadeFactory, arguments: Dict[str, Any]) -> None:
+        """
+        Modifies the service without capturing or restoring it.
+        :param facade_factory: Factory that produces objects capable of doing actual operations.
+        :param arguments: Dictionary containing any command line argument values defined in add_additional_arguments.
+        """
+        pass
+
+    @abc.abstractmethod
     def pre_restore_check(
             self,
             migration_directory: str,

--- a/nislmigrate/extensibility/migrator_plugin.py
+++ b/nislmigrate/extensibility/migrator_plugin.py
@@ -127,9 +127,10 @@ class MigratorPlugin(abc.ABC):
         """
         pass
 
-    def modify(self, facade_factory: FacadeFactory, arguments: Dict[str, Any]) -> None:
+    def modify(self, migration_directory: str, facade_factory: FacadeFactory, arguments: Dict[str, Any]) -> None:
         """
         Modifies the service without capturing or restoring it.
+        :param migration_directory: the root path to perform the restore from.
         :param facade_factory: Factory that produces objects capable of doing actual operations.
         :param arguments: Dictionary containing any command line argument values defined in add_additional_arguments.
         """

--- a/nislmigrate/facades/mongo_facade.py
+++ b/nislmigrate/facades/mongo_facade.py
@@ -166,6 +166,7 @@ class MongoFacade:
             collection_name: str,
             predicate: Callable[[Any], bool],
             update_function: Callable[[Any], Any]):
+        self.__start_mongo()
         client = MongoClient(configuration.connection_string)
         codec = bson.codec_options.CodecOptions(uuid_representation=bson.binary.UUID_SUBTYPE)
         database = client.get_database(name=configuration.database_name, codec_options=codec)

--- a/nislmigrate/migration_action.py
+++ b/nislmigrate/migration_action.py
@@ -7,4 +7,5 @@ class MigrationAction(Enum):
     """
     CAPTURE = 0
     RESTORE = 1
-    LIST = 2
+    MODIFY = 2
+    LIST = 3

--- a/nislmigrate/migration_facilitator.py
+++ b/nislmigrate/migration_facilitator.py
@@ -57,7 +57,7 @@ class MigrationFacilitator:
         elif self._action == MigrationAction.RESTORE:
             migrator.restore(migrator_directory, self.facade_factory, migrator_arguments)
         elif self._action == MigrationAction.MODIFY:
-            migrator.modify(self.facade_factory, migrator_arguments)
+            migrator.modify(migrator_directory, self.facade_factory, migrator_arguments)
         else:
             raise ValueError('Migration action is not the correct type.')
 

--- a/nislmigrate/migration_facilitator.py
+++ b/nislmigrate/migration_facilitator.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from nislmigrate.argument_handler import ArgumentHandler, CAPTURE_OR_RESTORE_NOT_PROVIDED_ERROR_TEXT
+from nislmigrate.argument_handler import ArgumentHandler, MIGRATION_OPERATION_NOT_PROVIDED_ERROR_TEXT
 from nislmigrate.facades.facade_factory import FacadeFactory
 from nislmigrate.facades.ni_web_server_manager_facade import NiWebServerManagerFacade
 from nislmigrate.logs.migration_error import MigrationError
@@ -13,7 +13,7 @@ from nislmigrate.utility.permission_checker import PermissionChecker
 
 class MigrationFacilitator:
     """
-    Facilitates an entire capture or restore operation from start to finish.
+    Facilitates an entire migration operation from start to finish.
     """
     def __init__(self, facade_factory: FacadeFactory, argument_handler: ArgumentHandler):
         self.facade_factory: FacadeFactory = facade_factory
@@ -24,14 +24,14 @@ class MigrationFacilitator:
         action_not_restore = not self._action == MigrationAction.RESTORE
         action_not_capture = not self._action == MigrationAction.CAPTURE
         action_not_modify = not self._action == MigrationAction.MODIFY
-        if action_not_restore and action_not_capture and action_not_restore:
-            raise MigrationError(CAPTURE_OR_RESTORE_NOT_PROVIDED_ERROR_TEXT)
+        if action_not_restore and action_not_capture and action_not_modify:
+            raise MigrationError(MIGRATION_OPERATION_NOT_PROVIDED_ERROR_TEXT)
         self._migrators = argument_handler.get_list_of_services_to_capture_or_restore()
         self._migration_directory = argument_handler.get_migration_directory()
         self._argument_handler = argument_handler
 
     def migrate(self):
-        """Facilitates an entire capture or restore operation from start to finish.
+        """Facilitates an entire migration operation from start to finish.
         """
 
         self.__pre_migration_error_check()
@@ -46,7 +46,7 @@ class MigrationFacilitator:
                 self.__migrate_service(migrator, migrator_directory)
                 self.__report_migration_finished(migrator.name)
         finally:
-            if self._action == MigrationAction.RESTORE:
+            if self._action == MigrationAction.RESTORE or self._action == MigrationAction.MODIFY:
                 self.web_server_manager.restart_web_server()
             self.service_manager.start_all_system_link_services()
 
@@ -64,9 +64,9 @@ class MigrationFacilitator:
     def __report_migration_starting(self, migrator_name: str):
         action_pretty_name = 'capture'
         if self._action == MigrationAction.RESTORE:
-          action_pretty_name = 'restore'
+            action_pretty_name = 'restore'
         if self._action == MigrationAction.MODIFY:
-          action_pretty_name = 'modify'
+            action_pretty_name = 'modify'
 
         migrator_names = (action_pretty_name, migrator_name)
         info = f'Starting to {action_pretty_name} data using {migrator_names} migrator strategy ...'
@@ -76,10 +76,10 @@ class MigrationFacilitator:
     def __report_migration_finished(self, migrator_name: str):
         action_pretty_name = 'capturing'
         if self._action == MigrationAction.RESTORE:
-          action_pretty_name = 'restoring'
+            action_pretty_name = 'restoring'
         if self._action == MigrationAction.MODIFY:
-          action_pretty_name = 'modifying'
-        
+            action_pretty_name = 'modifying'
+
         info = f'Done {action_pretty_name} data using {migrator_name} migrator strategy.'
         log = logging.getLogger(MigrationFacilitator.__name__)
         log.log(logging.INFO, info)
@@ -101,7 +101,7 @@ class MigrationFacilitator:
         elif self._action == MigrationAction.RESTORE:
             migrator.pre_restore_check(migrator_directory, self.facade_factory, arguments)
         elif self._action == MigrationAction.MODIFY:
-            pass
+            migrator.pre_modify_check(migrator_directory, self.facade_factory, arguments)
         else:
             raise ValueError('Migration action is not the correct type.')
         self.__report_pre_migration_check_finished(migrator.name)

--- a/nislmigrate/migration_facilitator.py
+++ b/nislmigrate/migration_facilitator.py
@@ -21,7 +21,10 @@ class MigrationFacilitator:
         self.service_manager: SystemLinkServiceManagerFacade = facade_factory.get_system_link_service_manager_facade()
 
         self._action = argument_handler.get_migration_action()
-        if not self._action == MigrationAction.RESTORE and not self._action == MigrationAction.CAPTURE:
+        action_not_restore = not self._action == MigrationAction.RESTORE
+        action_not_capture = not self._action == MigrationAction.CAPTURE
+        action_not_modify = not self._action == MigrationAction.MODIFY
+        if action_not_restore and action_not_capture and action_not_restore:
             raise MigrationError(CAPTURE_OR_RESTORE_NOT_PROVIDED_ERROR_TEXT)
         self._migrators = argument_handler.get_list_of_services_to_capture_or_restore()
         self._migration_directory = argument_handler.get_migration_directory()
@@ -53,18 +56,30 @@ class MigrationFacilitator:
             migrator.capture(migrator_directory, self.facade_factory, migrator_arguments)
         elif self._action == MigrationAction.RESTORE:
             migrator.restore(migrator_directory, self.facade_factory, migrator_arguments)
+        elif self._action == MigrationAction.MODIFY:
+            migrator.modify(self.facade_factory, migrator_arguments)
         else:
             raise ValueError('Migration action is not the correct type.')
 
     def __report_migration_starting(self, migrator_name: str):
-        action_pretty_name = 'capture' if self._action == MigrationAction.CAPTURE else 'restore'
+        action_pretty_name = 'capture'
+        if self._action == MigrationAction.RESTORE:
+          action_pretty_name = 'restore'
+        if self._action == MigrationAction.MODIFY:
+          action_pretty_name = 'modify'
+
         migrator_names = (action_pretty_name, migrator_name)
         info = f'Starting to {action_pretty_name} data using {migrator_names} migrator strategy ...'
         log = logging.getLogger(MigrationFacilitator.__name__)
         log.log(logging.INFO, info)
 
     def __report_migration_finished(self, migrator_name: str):
-        action_pretty_name = 'capturing' if self._action == MigrationAction.CAPTURE else 'restoring'
+        action_pretty_name = 'capturing'
+        if self._action == MigrationAction.RESTORE:
+          action_pretty_name = 'restoring'
+        if self._action == MigrationAction.MODIFY:
+          action_pretty_name = 'modifying'
+        
         info = f'Done {action_pretty_name} data using {migrator_name} migrator strategy.'
         log = logging.getLogger(MigrationFacilitator.__name__)
         log.log(logging.INFO, info)
@@ -85,6 +100,8 @@ class MigrationFacilitator:
             migrator.pre_capture_check(migrator_directory, self.facade_factory, arguments)
         elif self._action == MigrationAction.RESTORE:
             migrator.pre_restore_check(migrator_directory, self.facade_factory, arguments)
+        elif self._action == MigrationAction.MODIFY:
+            pass
         else:
             raise ValueError('Migration action is not the correct type.')
         self.__report_pre_migration_check_finished(migrator.name)

--- a/nislmigrate/migrators/file_migrator.py
+++ b/nislmigrate/migrators/file_migrator.py
@@ -32,8 +32,9 @@ _CHANGE_FILE_STORE_SLASHES_ARGUMENT = 'switch-to-forward-slashes'
 _CHANGE_FILE_STORE_SLASHES_HELP = 'Change the file storage location path from backward slashes to forward slashes'
 
 _FILE_STORE_ROOT_ARGUMENT = 'file-store-root'
-_FILE_STORE_ROOT_HELP = 'The file store root directory. Required when "--files-change-file-store-root" is specified \
-with the "modify" operation, ignored otherwise.'
+_FILE_STORE_ROOT_HELP = 'The file store root directory for file storage locations to be updated by \
+"--files-change-file-store-root" when run with the "modify" operation. For "restore" operations this \
+value is inferred from the database and this argument is ignored.'
 
 _NO_FILES_ERROR = """
 

--- a/nislmigrate/migrators/file_migrator.py
+++ b/nislmigrate/migrators/file_migrator.py
@@ -80,9 +80,10 @@ class _FileMigratorConfiguration:
         self.has_metadata_only_argument: bool = arguments.get(_METADATA_ONLY_ARGUMENT, False)
         self.should_migrate_files: bool = not self.has_metadata_only_argument
         self.update_store_path: str = arguments.get(_CHANGE_FILE_STORE_ARGUMENT, '')
-        self.old_store_path = ''
         if action is MigrationAction.MODIFY:
             self.old_store_path: str = arguments.get(_FILE_STORE_ROOT_ARGUMENT, '')
+        else:
+            self.old_store_path = ''
         self.should_update_store: bool = not self.update_store_path == ''
         self.use_forward_slashes: bool = arguments.get(_CHANGE_FILE_STORE_SLASHES_ARGUMENT, False)
 

--- a/nislmigrate/migrators/file_migrator.py
+++ b/nislmigrate/migrators/file_migrator.py
@@ -118,18 +118,24 @@ class FileMigrator(MigratorPlugin):
             configuration.mongo_configuration,
             migration_directory,
             self.name)
-
-        if configuration.should_update_store:
-            self.update_root_file_path_in_metadata(configuration)
-
-        if configuration.use_forward_slashes:
-            self.update_file_path_slashes_in_metadata(configuration)
-
+        self.modify(self, migration_directory, facade_factory, arguments)
         if configuration.should_migrate_files:
             configuration.file_facade.copy_directory(
                 configuration.file_migration_directory,
                 configuration.data_directory,
                 True)
+
+    def modify(self, migration_directory: str, facade_factory: FacadeFactory, arguments: Dict[str, Any]):
+        configuration = _FileMigratorConfiguration(
+            migration_directory,
+            facade_factory,
+            arguments,
+            self.config(facade_factory)
+        )
+        if configuration.should_update_store:
+            self.update_root_file_path_in_metadata(configuration)
+        if configuration.use_forward_slashes:
+            self.update_file_path_slashes_in_metadata(configuration)
 
     def pre_capture_check(
             self,

--- a/nislmigrate/migrators/file_migrator.py
+++ b/nislmigrate/migrators/file_migrator.py
@@ -7,6 +7,7 @@ from nislmigrate.facades.file_system_facade import FileSystemFacade
 from nislmigrate.facades.mongo_configuration import MongoConfiguration
 from nislmigrate.facades.mongo_facade import MongoFacade
 from nislmigrate.logs.migration_error import MigrationError
+from nislmigrate.migration_action import MigrationAction
 from nislmigrate.utility.paths import get_ni_application_data_directory_path
 
 DEFAULT_DATA_DIRECTORY = os.path.join(
@@ -30,6 +31,10 @@ _CHANGE_FILE_STORE_HELP = 'Change the file storage location path'
 _CHANGE_FILE_STORE_SLASHES_ARGUMENT = 'switch-to-forward-slashes'
 _CHANGE_FILE_STORE_SLASHES_HELP = 'Change the file storage location path from backward slashes to forward slashes'
 
+_FILE_STORE_ROOT_ARGUMENT = 'file-store-root'
+_FILE_STORE_ROOT_HELP = 'The file store root directory. Required when "--files-change-file-store-root" is specified \
+with the "modify" operation, ignored otherwise.'
+
 _NO_FILES_ERROR = """
 
 Files data was not found. If you intend to restore metadata only, pass
@@ -44,12 +49,20 @@ stored in S3. If you intend to migrate metadata only, pass --files-metadata-only
 
 """
 
+_FILE_STORE_ROOT_NOT_SET_FOR_MODIFY_CHANGE_FILE_STORE_ERROR = """
+
+--files-file-store-root must be set with operation 'modify --files-change-file-store-root'
+
+"""
+
 _SAVED_OLD_FILE_STORE_ROOT_FILE_NAME = 'file-store-root'
 
 
 class _FileMigratorConfiguration:
     def __init__(
-        self, migration_directory: str,
+        self,
+        action: MigrationAction,
+        migration_directory: str,
         facade_factory: FacadeFactory,
         arguments: Dict[str, Any],
         config: Dict[str, Any]
@@ -67,6 +80,9 @@ class _FileMigratorConfiguration:
         self.has_metadata_only_argument: bool = arguments.get(_METADATA_ONLY_ARGUMENT, False)
         self.should_migrate_files: bool = not self.has_metadata_only_argument
         self.update_store_path: str = arguments.get(_CHANGE_FILE_STORE_ARGUMENT, '')
+        self.old_store_path = ''
+        if action is MigrationAction.MODIFY:
+            self.old_store_path: str = arguments.get(_FILE_STORE_ROOT_ARGUMENT, '')
         self.should_update_store: bool = not self.update_store_path == ''
         self.use_forward_slashes: bool = arguments.get(_CHANGE_FILE_STORE_SLASHES_ARGUMENT, False)
 
@@ -87,6 +103,7 @@ class FileMigrator(MigratorPlugin):
 
     def capture(self, migration_directory: str, facade_factory: FacadeFactory, arguments: Dict[str, Any]):
         configuration = _FileMigratorConfiguration(
+            MigrationAction.CAPTURE,
             migration_directory,
             facade_factory,
             arguments,
@@ -108,6 +125,7 @@ class FileMigrator(MigratorPlugin):
 
     def restore(self, migration_directory: str, facade_factory: FacadeFactory, arguments: Dict[str, Any]):
         configuration = _FileMigratorConfiguration(
+            MigrationAction.RESTORE,
             migration_directory,
             facade_factory,
             arguments,
@@ -118,7 +136,9 @@ class FileMigrator(MigratorPlugin):
             configuration.mongo_configuration,
             migration_directory,
             self.name)
-        self.modify(self, migration_directory, facade_factory, arguments)
+        if configuration.should_update_store:
+            configuration.old_store_path = configuration.file_facade.read_file(_SAVED_OLD_FILE_STORE_ROOT_FILE_NAME)
+        self.update_database(configuration)
         if configuration.should_migrate_files:
             configuration.file_facade.copy_directory(
                 configuration.file_migration_directory,
@@ -127,6 +147,7 @@ class FileMigrator(MigratorPlugin):
 
     def modify(self, migration_directory: str, facade_factory: FacadeFactory, arguments: Dict[str, Any]):
         configuration = _FileMigratorConfiguration(
+            MigrationAction.MODIFY,
             migration_directory,
             facade_factory,
             arguments,
@@ -144,6 +165,7 @@ class FileMigrator(MigratorPlugin):
             arguments: Dict[str, Any]) -> None:
 
         configuration = _FileMigratorConfiguration(
+            MigrationAction.CAPTURE,
             migration_directory,
             facade_factory,
             arguments,
@@ -159,6 +181,7 @@ class FileMigrator(MigratorPlugin):
             arguments: Dict[str, Any]) -> None:
 
         configuration = _FileMigratorConfiguration(
+            MigrationAction.RESTORE,
             migration_directory,
             facade_factory,
             arguments,
@@ -174,13 +197,39 @@ class FileMigrator(MigratorPlugin):
         elif not configuration.file_migration_directory_exists and configuration.should_migrate_files:
             raise MigrationError(_NO_FILES_ERROR)
 
+    def pre_modify_check(
+            self,
+            migration_directory: str,
+            facade_factory: FacadeFactory,
+            arguments: Dict[str, Any]) -> None:
+
+        configuration = _FileMigratorConfiguration(
+            MigrationAction.MODIFY,
+            migration_directory,
+            facade_factory,
+            arguments,
+            self.config(facade_factory)
+        )
+        if configuration.update_store_path != '' and configuration.old_store_path == '':
+            raise MigrationError(_FILE_STORE_ROOT_NOT_SET_FOR_MODIFY_CHANGE_FILE_STORE_ERROR)
+
     def add_additional_arguments(self, argument_manager: ArgumentManager):
         argument_manager.add_switch(_METADATA_ONLY_ARGUMENT, help=_METADATA_ONLY_HELP)
-        argument_manager.add_argument(_CHANGE_FILE_STORE_ARGUMENT, help=_CHANGE_FILE_STORE_HELP, metavar='update')
+        argument_manager.add_argument(_CHANGE_FILE_STORE_ARGUMENT, help=_CHANGE_FILE_STORE_HELP, metavar='new-root-dir')
+        argument_manager.add_argument(
+            _FILE_STORE_ROOT_ARGUMENT,
+            help=_FILE_STORE_ROOT_HELP,
+            metavar='existing-root-dir')
         argument_manager.add_switch(_CHANGE_FILE_STORE_SLASHES_ARGUMENT, help=_CHANGE_FILE_STORE_SLASHES_HELP)
 
+    def update_database(self, configuration: _FileMigratorConfiguration):
+        if configuration.should_update_store:
+            self.update_root_file_path_in_metadata(configuration)
+        if configuration.use_forward_slashes:
+            self.update_file_path_slashes_in_metadata(configuration)
+
     def update_root_file_path_in_metadata(self, configuration: _FileMigratorConfiguration):
-        old_path = configuration.file_facade.read_file(_SAVED_OLD_FILE_STORE_ROOT_FILE_NAME)
+        old_path = configuration.old_store_path
         new_path = configuration.update_store_path
         collection_name = self.name.lower()
         does_path_field_start_with_old_path = self.does_path_start_with_prefix_predicate(old_path)


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.

What does this Pull Request accomplish?
Adds another command line option `modify` that allows the tool to perform action on a services data without migrating the service.

Why should this Pull Request be merged?
This allows updating the file paths from local storage to S3 without migrating the file service

What testing has been done?
Added additional unit tests
Tested manually with a SL 2021R1 install:
 - Used `manual_test/test_file.py` to populate the server with files
 - Duplicated the uploaded files to a different local location and to s3
 - Ran the tool to both duplicates
     - `nislmigrate modify --files --files-file-store-root <current> --files-change-file-store-root <s3> --files-switch-to-forward-slashes`
     - `nislmigrate modify --files --files-file-store-root <current> --files-change-file-store-root <second-local>`
 - In each case verified I can access the files via the Files app in browser and that the database was updated as expected using Robo 3T
