### PR TITLE
Update repository_migrator.py to fix Repository capture and migration feature

### DIFF
--- a/nislmigrate/migrators/repository_migrator.py
+++ b/nislmigrate/migrators/repository_migrator.py
@@ -21,7 +21,7 @@ class RepositoryMigrator(MigratorPlugin):
 
     @property
     def name(self):
-        return 'PackageRepository'
+        return 'Repository'
 
     @property
     def argument(self):


### PR DESCRIPTION
Fixes Issue [#147](https://github.com/ni/NI-SystemLink-Migration/issues/147): "Service 'PackageRepository' cannot be migrated because the specified service is not installed locally."

The service definition json for the package repository is %PROGRAMDATA%/Skyline/Config/Repository.json", which fails to match the RepositoryMigrator.name = "PackageRepository" property -> hence the service fails to be found by the module.

- [x] This contribution adheres to CONTRIBUTING.md.
TODO: Check the above box with an 'x' indicating you've read and followed CONTRIBUTING.md.

What does this Pull Request accomplish?
TODO: Fixes capture and migrate features for the *Repository* service.

Why should this Pull Request be merged?
TODO: Fix issue #147 

What testing has been done?
TODO: Tested successfully with SystemLink Server 21.0. Should hold true for any newer SystemLink Server instance with installed Repository service.
